### PR TITLE
feat: add init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # ESP8266-mqtt-boilerplate
 
 Template repository containing boilerplate code for setting up an ESP8266 with wifi, mqtt and over-the-air firmware flashing support.
+
+## Setup
+
+Run the `init.sh` script to give the `.ino` file the correct name for the project.

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get the name of the current project directory
+CURRENT_DIRECTORY="${PWD##*/}"
+
+# Change the name of the ino file to match the directory name
+mv esp8266-mqtt-boilerplate.ino "$CURRENT_DIRECTORY".ino
+
+# Commit the change
+git add "$CURRENT_DIRECTORY".ino
+git commit -m "initial commit"


### PR DESCRIPTION
The Arduino IDE requires the `*.ino` file to have the same name as the project directory. Running `init.sh´ will change the name of the template to match the name of the current directory.